### PR TITLE
Convert to Lower within Parse Function

### DIFF
--- a/app/create_db.py
+++ b/app/create_db.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import re
+import unicodedata
 from munch import DefaultMunch
 
 from .spell_check import *
@@ -10,7 +11,7 @@ def saveCharWords(rawArray, words):
     wordArray = []
     for i in words:
         if not re.search(r'[^a-zA-Z\']', rawArray[i]):
-            wordArray.append(rawArray[i])
+            wordArray.append(str(unicodedata.normalize('NFC', rawArray[i])).lower())
     return wordArray
 
 def assembleDB(wordArray):

--- a/app/create_db_test.py
+++ b/app/create_db_test.py
@@ -5,15 +5,15 @@ from .create_db import *
 class TestCreateDBMethods(unittest.TestCase):
     def test_saveCharWords(self):
         self.assertEqual(saveCharWords(['Here', ' ', 'is', ' ', 'a', ' ', 'sentence'], [0, 2, 4, 6]),
-                         ['Here', 'is', 'a', 'sentence'])
+                         ['here', 'is', 'a', 'sentence'])
         self.assertEqual(saveCharWords(['single'], [0]), ['single'])
-        self.assertEqual(parse_txt("I want 2 check numbers & characters"),
-                         (['I', ' ', 'want', ' ', '2', ' ', 'check', ' ', 'numbers', ' ', '&', ' ', 'characters'],
-                         [0, 2, 6, 8, 12]))
+        self.assertEqual(saveCharWords(['I', ' ', 'want', ' ', '2', ' ', 'check', ' ', 'numbers', ' ', '&', ' ',
+                                        'characters'], [0, 2, 4, 6, 8, 12]),
+                         ['i', 'want', 'check', 'numbers', 'characters'])
         self.assertEqual(saveCharWords(["Let's", ' ', 'test', ' ', 'this', '!', ' ', 'It', ' ', 'is', ' ', 'great', ' ',
                                         'to', ' ','be', ' ', '@', ' ', 'the', ' ', 'ballgame', ',', ' ', 'with', ' ',
                                         'my', ' ', 'friend', '!'],
-                         [0, 2, 4, 7, 9, 11, 13, 15, 19, 21, 24, 26, 28]), ["Let's", 'test', 'this', 'It', 'is', 'great',
+                         [0, 2, 4, 7, 9, 11, 13, 15, 19, 21, 24, 26, 28]), ["let's", 'test', 'this', 'it', 'is', 'great',
                                         'to', 'be', 'the', 'ballgame', 'with', 'my', 'friend'])
         self.assertEqual(saveCharWords(['an',' ', 'email', ' ', 'address', ':', ' ', 'Email@goog.com'], [0, 2, 4, 7]),
                          ['an','email', 'address'])


### PR DESCRIPTION
This will need to be rebased and then delivered after the Regex Refactor branch.

This update will ensure the full dictionaries are all lower case characters and that the text coming in from the front end is also all lower case characters.