### PR TITLE
Added Metrics Calculations & Expanded Dict Building

### DIFF
--- a/app/create_db.py
+++ b/app/create_db.py
@@ -12,8 +12,27 @@ def saveCharWords(rawArray, words):
             wordArray.append(str(unicodedata.normalize('NFC', rawArray[i])).lower())
     return wordArray
 
-def assembleDB(wordArray):
+def initDB(wordArray):
     db = {}
+    for word in wordArray:
+        tmp_word = Word(word)
+        tmp_word.setInstances(0)
+        db.update({word: tmp_word})
+    return db
+
+def assembleDB(wordArray, db):
+    # ** Uncomment this code if you want to only use wordArray for adding context
+    #    and have already added all 'real' words to the db **
+    # if db != {}:
+    #     for i, word in enumerate(wordArray):
+    #         if i+2 < len(wordArray) and word in db:
+    #             if word in db:
+    #                 db[word].addContext(wordArray[i + 2], wordArray[i + 1])
+    #         elif i+1 < len(wordArray) and word in db:
+    #             db[word].addContext('', wordArray[i + 1])
+    #         elif word in db:
+    #             db[word].incrmtInstances()
+    # else:
     for i, word in enumerate(wordArray):
         if i+2 < len(wordArray):
             if word in db:
@@ -41,11 +60,12 @@ def filterDB(db, minInstances, minConstantInst):
 def db_to_dict(db):
     db_dict = {}
     for key in db:
-        db_dict[key] = db[key].__dict__
+        db_dict.update({key: vars(db[key])})
+        #db_dict[key] = db[key].__dict__
     return db_dict
 
 def dict_to_db(dict_db):
     db = {}
     for word in dict_db:
-        db[word] = DefaultMunch.fromDict(dict_db[word])
+        db.update({word: Word(**dict_db[word])})
     return db

--- a/app/create_db_test.py
+++ b/app/create_db_test.py
@@ -19,7 +19,7 @@ class TestCreateDBMethods(unittest.TestCase):
                          ['an','email', 'address'])
 
     def test_assembleDB(self):
-        test_db = assembleDB(['here', 'is', 'a', 'sentence', 'there', 'are', 'repeats', 'this', 'is', 'a', 'test'])
+        test_db = assembleDB(['here', 'is', 'a', 'sentence', 'there', 'are', 'repeats', 'this', 'is', 'a', 'test'], {})
         self.assertEqual({'a': {'is': 1}}, test_db['here'].context)
         self.assertEqual(1, test_db['here'].instances)
         self.assertEqual({'sentence': {'a': 1}, 'test': {'a': 1}}, test_db['is'].context)
@@ -29,7 +29,7 @@ class TestCreateDBMethods(unittest.TestCase):
     def test_filterDB(self):
         test_db = assembleDB(['here', 'is', 'a', 'sentence', 'there', 'are', 'repeats', 'this', 'is', 'a', 'test',
                               'we', 'want', 'there', 'to', 'be', 'repeat', 'sentence', 'so', 'that', 'there', 'can',
-                              'be', 'a', 'test', 'it', 'is', 'a', 'test', 'there', 'to', 'be'])
+                              'be', 'a', 'test', 'it', 'is', 'a', 'test', 'there', 'to', 'be'], {})
         filterDB(test_db, 2, 2)
         self.assertEqual({'test': {'a': 2}}, test_db['is'].context)
         self.assertEqual(3, test_db['is'].instances)

--- a/app/testset_main.py
+++ b/app/testset_main.py
@@ -22,14 +22,27 @@ text = f.read()
 word_list = text.splitlines()
 f.close()
 
-f = open(args.ts)
-text = f.read()
-word_list = text.splitlines()
+f = open(args.ta)
+text_ans = f.read()
 f.close()
+
+answer_lines = text_ans.splitlines()
+answer_list = []
+for line in answer_lines:
+    temp_ans = line.split('\t')
+    if len(temp_ans) == 1:
+        temp_ans.append('')
+    answer_list.append(temp_ans)
 
 helper = LanguageHelper(test_dictDB, args.l)
 
 retVal = []
+true_pos = 0
+true_neg = 0
+false_pos = 0
+false_neg = 0
+correct_rec = 0
+incorrect_rec = 0
 for idx, word in enumerate(word_list):
     lower_word = toLower(word)
     if args.l == "English":
@@ -77,8 +90,35 @@ for idx, word in enumerate(word_list):
         else:
             retVal.append([word, word])
 
+    if answer_list[idx][0] == answer_list[idx][1]:
+        if retVal[idx][0] == retVal[idx][1]:
+            true_neg += 1
+        else:
+            false_pos += 1
+    else:
+        if retVal[idx][0] != retVal[idx][1]:
+            true_pos += 1
+        else:
+            false_neg += 1
+
+        if retVal[idx][1] == answer_list[idx][1]:
+            correct_rec += 1
+        else:
+            incorrect_rec += 1
+
 with open("testSet_out.tsv","w+") as my_tsv:
     csvWriter = csv.writer(my_tsv,delimiter='\t')
     csvWriter.writerows(retVal)
 
 my_tsv.close()
+
+accuracy_recs = correct_rec / (correct_rec + incorrect_rec)
+precision = true_pos / (true_pos + false_pos)
+recall = true_pos / (true_pos + false_neg)
+f1_score = 2 * (precision * recall) / (precision + recall)
+print("True Positive - True Negative - False Positive - False Negative")
+print(str(true_pos) + " " + str(true_neg) + " " + str(false_pos) + " " + str(false_neg))
+print("F1 Score: " + str(f1_score))
+print("Recall: " + str(recall))
+print("Precision: " + str(precision))
+print("Rec Accuracy: " + str(accuracy_recs))


### PR DESCRIPTION
Added the ability to read in a file with answers in testset_main.py and to calcluate metrics of the results of
  spell checking.
Added ability to initialize a dictionary database with only words and no context.
Added option (currently commented out) to assemble database based on initialized db where word array only adds
  context and not new words to the dictionary. Currently this does not improve effectiveness but leaving in so
  that it can be revisted later during testing.